### PR TITLE
Fix geocode error on frontpage

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -97,3 +97,11 @@ App::import('Lib', 'Wannabe');
 
 //Load Composer
 App::import('Vendor', ['file' => 'autoload']);
+
+// Google maps configuration
+Configure::write(
+    'GoogleMaps',
+    array(
+       'apiKey' => env('GOOGLEMAPS_APIKEY') ? env('GOOGLEMAPS_APIKEY') : 'AIzaSyAl0C6hB_SxHgBhTGaXdRNysxWSyPvdND8',
+    )
+);

--- a/app/Controller/Component/GeocodeCacheComponent.php
+++ b/app/Controller/Component/GeocodeCacheComponent.php
@@ -10,6 +10,8 @@ class GeocodeCacheComponent extends Component {
     var $userNeedGeocodeUpdate = false;
 
 	public function initialize(&$controller) {
+        $this->apiKey = Configure::read('GoogleMaps.apiKey');
+
         if(isset($controller->Wannabe->user['User']) && $controller->Acl->hasMembershipToEvent($controller->Wannabe->user)) {
             $this->userAddress = $controller->Wannabe->user['User']['address']." ".$controller->Wannabe->user['User']['postcode']." ".$controller->Wannabe->user['User']['town'];
             $this->cache = $this->loadGeocodeCache();

--- a/app/View/Crew/list-map.ctp
+++ b/app/View/Crew/list-map.ctp
@@ -130,7 +130,7 @@
     function loadGoogleMapsAPI() {
         var s=document.createElement("script");
         s.type="text/javascript";
-        s.src="https://maps.googleapis.com/maps/api/js?key=<?=$geocode->apikey?>&sensor=false&callback=initGoogleMapsAPI";
+        s.src="https://maps.googleapis.com/maps/api/js?key=<?=$geocode->apiKey?>&sensor=false&callback=initGoogleMapsAPI";
         document.body.appendChild(s);
     }
     window.onload = loadGoogleMapsAPI;

--- a/app/View/Home/index-old.ctp
+++ b/app/View/Home/index-old.ctp
@@ -219,7 +219,7 @@ if(!$crewmember && isset($cfadSettings['CfadApplicationSetting']['can_apply']) &
     function loadGoogleMapsAPI() {
         var s=document.createElement("script");
         s.type="text/javascript";
-        s.src="https://maps.googleapis.com/maps/api/js?key=<?=$geocode->apikey?>&sensor=false&callback=initUserGeocoder";
+        s.src="https://maps.googleapis.com/maps/api/js?key=<?=$geocode->apiKey?>&sensor=false&callback=initUserGeocoder";
         document.body.appendChild(s);
     }
     window.onload = loadGoogleMapsAPI;

--- a/app/View/Home/index.ctp
+++ b/app/View/Home/index.ctp
@@ -221,7 +221,7 @@
     function loadGoogleMapsAPI() {
         var s=document.createElement("script");
         s.type="text/javascript";
-        s.src="https://maps.googleapis.com/maps/api/js?key=<?=$geocode->apikey?>&sensor=false&callback=initUserGeocoder";
+        s.src="https://maps.googleapis.com/maps/api/js?key=<?=$geocode->apiKey?>&sensor=false&callback=initUserGeocoder";
         document.body.appendChild(s);
     }
     window.onload = loadGoogleMapsAPI;


### PR DESCRIPTION
Re-adds the missing Google Maps API key in order to get rid of geocode errors.

Not sure if we have any conventions for where to put these kind of configuration options yet. So just put it straight into `Config/bootstrap` with a default value and optional ENV override.

Fixes: https://github.com/gathering/wannabe/issues/16