### PR TITLE
make error text less suggestive

### DIFF
--- a/app/Locale/nob/LC_MESSAGES/default.po
+++ b/app/Locale/nob/LC_MESSAGES/default.po
@@ -6049,8 +6049,8 @@ msgid "Error"
 msgstr "Feil"
 
 #: View/Errors/error400.ctp:23
-msgid "The page “%s” returned an error. Maybe you did something wrong?"
-msgstr "Siden «%s» returnerte en feilmelding. Kan du ha gjort noe feil?"
+msgid "The page “%s” returned an error. Please try again, or contant support."
+msgstr "Siden «%s» returnerte en feilmelding. Vennligst prøv igjen, eller kontakt support."
 
 #: View/Errors/error400.ctp:32
 msgid ""

--- a/app/Locale/nob/LC_MESSAGES/default.po
+++ b/app/Locale/nob/LC_MESSAGES/default.po
@@ -6049,7 +6049,7 @@ msgid "Error"
 msgstr "Feil"
 
 #: View/Errors/error400.ctp:23
-msgid "The page “%s” returned an error. Please try again, or contact support."
+msgid "The page “%s” returned an error. Please try again, or contact the system administrators."
 msgstr "Siden «%s» returnerte en feilmelding. Vennligst prøv igjen, eller kontakt systemansvarlig."
 
 #: View/Errors/error400.ctp:32

--- a/app/Locale/nob/LC_MESSAGES/default.po
+++ b/app/Locale/nob/LC_MESSAGES/default.po
@@ -6050,7 +6050,7 @@ msgstr "Feil"
 
 #: View/Errors/error400.ctp:23
 msgid "The page “%s” returned an error. Please try again, or contact support."
-msgstr "Siden «%s» returnerte en feilmelding. Vennligst prøv igjen, eller kontakt support."
+msgstr "Siden «%s» returnerte en feilmelding. Vennligst prøv igjen, eller kontakt systemansvarlig."
 
 #: View/Errors/error400.ctp:32
 msgid ""

--- a/app/Locale/nob/LC_MESSAGES/default.po
+++ b/app/Locale/nob/LC_MESSAGES/default.po
@@ -6049,7 +6049,7 @@ msgid "Error"
 msgstr "Feil"
 
 #: View/Errors/error400.ctp:23
-msgid "The page “%s” returned an error. Please try again, or contant support."
+msgid "The page “%s” returned an error. Please try again, or contact support."
 msgstr "Siden «%s» returnerte en feilmelding. Vennligst prøv igjen, eller kontakt support."
 
 #: View/Errors/error400.ctp:32


### PR DESCRIPTION
Todays error text for 400 errors might be a bit suggestive, especially when most of the times this error shows up, the user haven't done anything obviously wrong.