### PR TITLE
Remove user nickname requirement

### DIFF
--- a/app/Controller/ProfileController.php
+++ b/app/Controller/ProfileController.php
@@ -302,7 +302,9 @@ class ProfileController extends AppController {
             $this->set('improtocols', $this->Improtocol->find('list'));
             $this->set('phonetypes', $this->Phonetype->find('list'));
             $this->set('title_for_layout', WbSanitize::clean($user['User']['realname']));
-            $this->set('desc_for_layout', __('aka')." ".WbSanitize::clean($user['User']['nickname']));
+            if (!empty($user['User']['nickname'])) {
+                $this->set('desc_for_layout', __('aka')." ".WbSanitize::clean($user['User']['nickname']));
+            }
             $this->set('userAge', $this->calculateAge($user['User']['birth']));
             $this->set('canViewDetailedInfo', $this->Acl->hasAccessToDetailedUserInfo($this->Wannabe->user));
             $this->set('canViewPhone',   $sharesCrewAndAllowsCrew || $this->Acl->hasAccessToViewUserDetail('phone', $user));

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -57,10 +57,6 @@ class User extends AppModel {
 				'rule' => 'notBlank',
 				'message' => __("Name cannot be empty")
 			),
-			'nickname' => array(
-				'rule' => 'notBlank',
-				'message' => __("Nick cannot be empty")
-			),
 			'town' => array(
 				'rule' => 'notBlank',
 				'message' => __("Town cannot be empty")


### PR DESCRIPTION
Removes `notBlank` nickname validation from User model, and hides `aka ...` from user profile page when not present.

Fixes: https://github.com/gathering/wannabe/issues/11