### PR TITLE
Bootstrap validation styles on (profile) forms

### DIFF
--- a/app/View/Helper/WbHelper.php
+++ b/app/View/Helper/WbHelper.php
@@ -76,6 +76,21 @@ class WbHelper extends HtmlHelper
 		return false;
 	}
 
+	public function useBootstrapForms() {
+		$this->Form->inputDefaults([
+			'class' => 'form-control',
+			'error' => [
+				'attributes' => [
+					'class' => 'help-block',
+				],
+			],
+			'div' => [
+				'class' => 'form-group',
+				'errorClass' => 'has-error',
+			],
+		]);
+	}
+
 	public function textarea($fieldName, $htmlAttributes=array(), $return=false, $value=false)
 	{
 		$fields = split('[.]', $fieldName);

--- a/app/View/Profile/email-verify.ctp
+++ b/app/View/Profile/email-verify.ctp
@@ -1,20 +1,16 @@
+<? $this->Wb->useBootstrapForms(); ?>
 <div class="row">
 	<div class="col-md-4">
 		<h2><?=__("Verify email")?></h2>
-		<p><?=__("Please click the link in your email to verify your new email address. If you would like to cancel please to som by clicking the button to the right.")?></p>
+		<p><?=__("Please click the link in your email to verify your new email address. If you would like to cancel please do so by clicking the button to the right.")?></p>
 	</div>
 	<div class="col-md-8">
 		<form method="POST">
 		<fieldset>
 			<legend><?=__("Change email")?></legend>
-			<div class="clearfix">
-				<label for="data[User][email]"><?=__("New email")?></label>
-				<div class="input">
-					<?=$this->Form->input('User.email', array('disabled' => 'disabled', 'div' => false, 'error' => false, 'label' => false, 'value' => $data['User']['email']))?>
-				</div>
-			</div>
+	        <?=$this->Form->input('User.email', ['disabled' => true, 'value' => $data['User']['email'], 'label' => __("New email")])?>
 			<div class="actions">
-				<?=$this->Form->submit(__("Cancel email change"), array('class' => 'btn danger','name'=>'cancel'))?>
+				<?=$this->Form->submit(__("Cancel email change"), array('class' => 'btn btn-danger','name'=>'cancel'))?>
 			</div>
 		</fieldset>
 		</form>

--- a/app/View/Profile/email.ctp
+++ b/app/View/Profile/email.ctp
@@ -1,3 +1,4 @@
+<? $this->Wb->useBootstrapForms(); ?>
 <div class="row">
 	<div class="col-md-3">
 		<h2><?=__("Edit your profile")?></h2>
@@ -11,18 +12,8 @@
 		<form method="POST">
 		<fieldset>
 			<legend><?=__("Change email")?></legend>
-			<div class="clearfix">
-				<div class="input">
-					<span><?=__("Your current email: %s", $wannabe->user['User']['email'])?></span>
-				</div>
-			</div>
-			<div class="clearfix <? if($this->Form->error('User.email')) echo "error"; ?>">
-				<label for="data[User][email]"><?=__("New email")?></label>
-				<div class="input">
-					<?=$this->Form->input('User.email', array('div' => false, 'error' => false, 'class'=>'form-control', 'label' => false, 'value' => $data['User']['email']))?>
-					<span class="help-block"><?=$this->Form->error('User.email')?></span>
-				</div>
-			</div>
+			<p><?=__("Your current email: %s", $wannabe->user['User']['email'])?></p>
+	        <?=$this->Form->input('User.email', ['value' => $data['User']['email'], 'label' => __("New email")])?>
 			<div class="actions">
 				<?=$this->Form->submit(__("Change email"), array('class' => 'btn btn-success','name'=>'change'))?>
 			</div>

--- a/app/View/Profile/form.ctp
+++ b/app/View/Profile/form.ctp
@@ -1,29 +1,12 @@
 <form method="POST">
 <?=$this->Html->script('wannabe/profile')?>
+<? $this->Wb->useBootstrapForms(); ?>
 <fieldset>
 	<legend><?=__("Personal info")?></legend>
-	<div class="clearfix <? if($this->Form->error('User.realname')) echo "error"; ?>">
-		<label for="data[User][realname]"><?=__("Full name")?></label>
-		<div class="input">
-			<?=$this->Form->input('User.realname', array('div' => false, 'error' => false,'class'=>'form-control', 'label' => false, 'value' => $user['User']['realname']))?>
-			<span class="help-block"><?=$this->Form->error('User.realname')?></span>
-		</div>
-	</div>
-	<div class="clearfix  <? if($this->Form->error('User.nickname')) echo "error"; ?>">
-		<label for="data[User][nickname]"><?=__("Nick")?></label>
-		<div class="input">
-			<?=$this->Form->input('User.nickname', array('div' => false, 'error' => false, 'class'=>'form-control', 'label' => false, 'value' => $user['User']['nickname']))?>
-			<span class="help-block"><?=$this->Form->error('User.nickname')?></span>
-		</div>
-	</div>
-	<div class="clearfix <? if($this->Form->error('User.sexe')) echo "error"; ?>">
-		<label for="data[User][sexe]"><?=__("Gender")?></label>
-		<div class="input">
-			<?=$this->Form->select('User.sexe', $sexes, array('div' => false, 'error' => false,'class'=>'form-control', 'label' => false, 'empty' => __("Gender"), 'value' => $user['User']['sexe']))?>
-			<span class="help-block"><?=$this->Form->error('User.sexe')?></span>
-		</div>
-	</div>
-	<div class="clearfix <? if($this->Form->error('User.birth')) echo "error"; ?>">
+	<?=$this->Form->input('User.realname', array('value' => $user['User']['realname'], 'label' => __("Full name")))?>
+	<?=$this->Form->input('User.nickname', array('value' => $user['User']['nickname'], 'label' => __("Nick")))?>
+	<?=$this->Form->input('User.sexe', array('value' => $user['User']['sexe'], 'label' => __("Gender")))?>
+	<div class="clearfix <? if($this->Form->error('User.birth')) echo "has-error"; ?>">
 		<label for="data[User][birth]"><?=__("Birth")?></label>
 		<div class="input">
 			<div class="row">
@@ -40,142 +23,71 @@
 			<span class="help-block"><?=$this->Form->error('User.birth')?></span>
 		</div>
 	</div>
-	<div class="clearfix <? if($this->Form->error('User.countrycode')) echo "error"; ?>">
-		<label for="data[User][countrycode]"><?=__("Country")?></label>
-		<div class="input">
-			<?=$this->Form->select('User.countrycode', $countrycodes, array('empty' => __("Country"), 'div' => false, 'class'=>'form-control', 'error' => false, 'label' => false, 'value' => $user['User']['countrycode']))?>
-			<span class="help-block"><?=$this->Form->error('User.countrycode')?></span>
-		</div>
-	</div>
-	<div class="clearfix <? if($this->Form->error('User.address')) echo "error"; ?>">
-		<label for="data[User][address]"><?=__("Address")?></label>
-		<div class="input">
-			<?=$this->Form->text('User.address', array('div' => false, 'error' => false, 'label' => false, 'class'=>'form-control', 'value' => $user['User']['address']))?>
-			<span class="help-block"><?=$this->Form->error('User.address')?></span>
-		</div>
-	</div>
-	<div class="clearfix <? if($this->Form->error('User.postcode')) echo "error"; ?>">
-		<label for="data[User][postcode]"><?=__("Postnummer")?></label>
-		<div class="input">
-			<?=$this->Form->text('User.postcode', array('div' => false, 'error' => false, 'label' => false, 'class'=>'form-control', 'value' => $user['User']['postcode']))?>
-			<span class="help-block"><?=$this->Form->error('User.postcode')?></span>
-		</div>
-	</div>
-	<div class="clearfix <? if($this->Form->error('User.town')) echo "error"; ?>">
-		<label for="data[User][town]"><?=__("Town")?></label>
-		<div class="input">
-			<?=$this->Form->text('User.town', array('div' => false, 'error' => false, 'label' => false, 'class'=>'form-control', 'value' => $user['User']['town']))?>
-			<span class="help-block"><?=$this->Form->error('User.town')?></span>
-		</div>
-	</div>
+	<?=$this->Form->input('User.countrycode', array('value' => $user['User']['countrycode'], 'label' => __("Country")))?>
+	<?=$this->Form->input('User.address', array('value' => $user['User']['address'], 'label' => __("Address")))?>
+	<?=$this->Form->input('User.postcode', array('value' => $user['User']['postcode'], 'label' => __("Postnummer")))?>
+	<?=$this->Form->input('User.town', array('value' => $user['User']['town'], 'label' => __("Town")))?>
 </fieldset>
 <fieldset>
 	<legend><?=__("Contact info")?></legend>
+
 <?php
-$lastindex = -1;
-if(isset($user['Userphone']) and sizeof($user['Userphone'])) {
-	$first = true;
-	foreach($user['Userphone'] as $index => $phone) {
-	$lastindex = $index;
+$userphone = (isset($user['Userphone']) and sizeof($user['Userphone'])) ? $user['Userphone'] : [];
+$userphone[] = [
+	'phonetype_id' => null,
+	'number' => null,
+];
+$first = true;
+foreach($userphone as $index => $phone) {
+	if ($first) {
+		$first = false;
+		echo $this->Form->label('Userphone'.$index.'PhonetypeId', __("Phone numbers"));
+	}
 ?>
-	<div class="clearfix <? if(isset($validateErrors['Userphone.'.$index.'.number'])) echo "error"; ?>">
-<?php
-		if($first) {
-			$first = false;
-?>
-		<label for="data[Userphone][<?=$index?>][phonetype_id]"><?=__("Phone numbers")?></label>
-<?php
-		}
-?>
+	<div class="clearfix <? if(isset($validateErrors['Userphone.'.$index.'.number'])) echo "has-error"; ?>">
 		<div class="input">
 			<div class="row">
 				<div class="col-md-4">
-				<?=$this->Form->select('Userphone.'.$index.'.phonetype_id', $phonetypes, array('div' => false, 'class'=>'form-control', 'label' => false,'empty' => __("Type"), 'value' => $phone['phonetype_id']))?>
+					<?=$this->Form->input('Userphone.'.$index.'.phonetype_id', array('div' => false, 'label' => false,'empty' => __("Type"), 'value' => $phone['phonetype_id']))?>
 				</div>
 				<div class="col-md-8">
-					<?=$this->Form->text('Userphone.'.$index.'.number', array('div' => false, 'label' => false, 'class'=>'form-control', 'value' => $phone['number']))?>
+					<?=$this->Form->input('Userphone.'.$index.'.number', array('div' => false, 'label' => false, 'value' => $phone['number']))?>
 				</div>
 			</div>
 			<span class="help-block"><? if(isset($validateErrors['Userphone.'.$index.'.number'])) { echo $validateErrors['Userphone.'.$index.'.number'][0]; } ?></span>
 		</div>
 	</div>
 <?php
-	}
 }
-		$lastindex = $lastindex+1;
+
+$userims = (isset($user['Userim']) && sizeof($user['Userim'])) ? $user['Userim'] : [];
+$userims[] = [
+	'improtocol_id' => null,
+	'address' => null,
+];
+$first = true;
+foreach($userims as $index => $account) {
+	if ($first) {
+		$first = false;
+		echo $this->Form->label('Userim'.$index.'ImprotocolId', __("IM accounts"));
+	}
 ?>
-	<div class="clearfix <? if(isset($validateErrors['Userphone.'.$lastindex.'.number'])) echo "error"; ?>">
-<?php
-		if($lastindex == 0) {
-?>
-		<label for="data[Userphone][<?=$lastindex?>][phonetype_id]"><?=__("Phone numbers")?></label>
-<?php
-		}
-?>
+	<div class="clearfix <? if(isset($validateErrors['Userim.'.$index.'.improtocol_id'])) echo "has-error"; ?>">
 		<div class="input">
 			<div class="row">
-			<div class="col-md-4">
-				<?=$this->Form->select('Userphone.'.$lastindex.'.phonetype_id', $phonetypes, array('div' => false, 'class'=>'form-control', 'label' => false, 'empty' => __("Type")))?>
+				<div class="col-md-4">
+					<?=$this->Form->input('Userim.'.$index.'.improtocol_id', ['div' => false, 'label' => false, 'empty' => __("Type"), 'value' => $account['improtocol_id']])?>
 				</div>
 				<div class="col-md-8">
-				<?=$this->Form->text('Userphone.'.$lastindex.'.number', array('div' => false, 'class'=>'form-control', 'label' => false))?>
+					<?=$this->Form->input('Userim.'.$index.'.address', ['div' => false, 'label' => false, 'value' => $account['address']])?>
 				</div>
-			</div>
-			<span class="help-block"><? if(isset($validateErrors['Userphone.'.$lastindex.'.number'])) { echo $validateErrors['Userphone.'.$lastindex.'.number'][0]; } else { echo __("Phone numbers should be entered with country prefix"); } ?></span>
-		</div>
-	</div>
-<?php
-$lastindex = -1;
-if(isset($user['Userim']) && sizeof($user['Userim'])) {
-	$first = true;
-	foreach($user['Userim'] as $index => $account) {
-		$lastindex = $index;
-?>
-	<div class="clearfix <? if(isset($validateErrors['Userim.'.$index.'.improtocol_id'])) echo "error"; ?>">
-<?php
-		if($first) {
-			$first = false;
-?>
-		<label for="data[Userim][<?=$index?>][improtocol_id]"><?=__("IM accounts")?></label>
-<?php
-		}
-?>
-		<div class="input">
-			<div class="row">
-			<div class="col-md-4">
-				<?=$this->Form->select('Userim.'.$index.'.improtocol_id', $improtocols, array('class' => 'form-control','div' => false, 'label' => false, 'empty' => __("Type"), 'value' => $account['improtocol_id']))?>
-			</div>
-			<div class="col-md-8">
-				<?=$this->Form->text('Userim.'.$index.'.address', array('class' => 'form-control','div' => false, 'label' => false, 'value' => $account['address']))?>
-			</div>
 			</div>
 			<span class="help-block"><? if(isset($validateErrors['Userim.'.$index.'.improtocol_id'])) { echo __("IM account type must be chosen"); } ?></span>
 		</div>
 	</div>
-
 <?php
-	}
 }
 ?>
-	<div class="clearfix">
-<?php
-		$lastindex = $lastindex+1;
-		if($lastindex == 0) {
-?>
-		<label for="data[Userim][<?=$lastindex?>][improtocol_id]"><?=__("IM accounts")?></label>
-<?php
-		}
-?>
-		<div class="input">
-			<div class="row">
-				<div class="col-md-4">
-				<?=$this->Form->select('Userim.'.$lastindex.'.improtocol_id', $improtocols, array('class' => 'form-control','div' => false, 'label' => false, 'empty' => __("Type")))?>
-			</div>
-			<div class="col-md-8">
-				<?=$this->Form->text('Userim.'.$lastindex.'.address', array('class' => 'form-control','div' => false, 'label' => false))?>
-			</div>
-			</div>
-		</div>
 	</div>
 	<div class="row">
 		<div class="col-md-12" style="margin-top: 20px;">

--- a/app/View/Profile/password-form.ctp
+++ b/app/View/Profile/password-form.ctp
@@ -1,27 +1,10 @@
+<? $this->Wb->useBootstrapForms(); ?>
 <form method="POST">
 <fieldset>
 	<legend><?=__("Update password")?></legend>
-	<div class="clearfix <? if($this->Form->error('User.password')) echo "error"; ?>">
-		<label for="data[User][password]"><?=__("Old password")?></label>
-		<div class="input">
-			<?=$this->Form->password('User.password', array('div' => false, 'error' => false, 'class'=>'form-control', 'label' => false, 'value' => ''))?>
-			<span class="help-block"><?=$this->Form->error('User.password')?></span>
-		</div>
-	</div>
-	<div class="clearfix <? if($this->Form->error('User.newpassword1')) echo "error"; ?>">
-		<label for="data[User][newpassword1]"><?=__("New password")?></label>
-		<div class="input">
-			<?=$this->Form->password('User.newpassword1', array('div' => false, 'error' => false, 'class'=>'form-control','label' => false, 'value' => ''))?>
-			<span class="help-block"><?=$this->Form->error('User.newpassword1')?></span>
-		</div>
-	</div>
-	<div class="clearfix <? if($this->Form->error('User.newpassword2')) echo "error"; ?>">
-		<label for="data[User][newpassword2]"><?=__("Confirm password")?></label>
-		<div class="input">
-			<?=$this->Form->password('User.newpassword2', array('div' => false, 'error' => false, 'class'=>'form-control', 'label' => false, 'value' => ''))?>
-			<span class="help-block"><?=$this->Form->error('User.newpassword2')?></span>
-		</div>
-	</div>
+	<?=$this->Form->input('User.password', ['label' => __("Old password"), 'type' => 'password'])?>
+	<?=$this->Form->input('User.newpassword1', ['label' => __("Password"), 'type' => 'password'])?>
+	<?=$this->Form->input('User.newpassword2', ['label' => __("Confirm password"), 'type' => 'password'])?>
 	<div class="actions">
 		<?=$this->Form->submit(__("Update password"), array('class' => 'btn btn-success','name'=>'save'))?>
 	</div>

--- a/app/View/Profile/password-register-form.ctp
+++ b/app/View/Profile/password-register-form.ctp
@@ -1,20 +1,9 @@
+<? $this->Wb->useBootstrapForms(); ?>
 <form method="POST">
 <fieldset>
 	<legend><?=__("Create password")?></legend>
-	<div class="clearfix <? if($this->Form->error('User.newpassword1')) echo "error"; ?>">
-		<label for="data[User][newpassword1]"><?=__("Password")?></label>
-		<div class="input">
-			<?=$this->Form->password('User.newpassword1', array('div' => false, 'error' => false, 'class'=>'form-control', 'label' => false, 'value' => ''))?>
-			<span class="help-block"><?=$this->Form->error('User.newpassword1')?></span>
-		</div>
-	</div>
-	<div class="clearfix <? if($this->Form->error('User.newpassword2')) echo "error"; ?>">
-		<label for="data[User][newpassword2]"><?=__("Confirm password")?></label>
-		<div class="input">
-			<?=$this->Form->password('User.newpassword2', array('div' => false, 'error' => false, 'class'=>'form-control', 'label' => false, 'value' => ''))?>
-			<span class="help-block"><?=$this->Form->error('User.newpassword2')?></span>
-		</div>
-	</div>
+	<?=$this->Form->input('User.newpassword1', ['label' => __("Password"), 'type' => 'password'])?>
+	<?=$this->Form->input('User.newpassword2', ['label' => __("Confirm password"), 'type' => 'password'])?>
 	<div class="actions" style="margin-top: 20px;">
 		<?=$this->Form->submit(__("Create password"), array('class' => 'btn btn-success','name'=>'save'))?>
 	</div>


### PR DESCRIPTION
While looking at the empty nick issue (and the earlier password related tweaks) I noticed there where quite a few fields which did not present user feedback in a clear manner. Most likely many forms are still configured for whatever "old" CSS styling was used before bootstrap.

This PR adds a small helper where we can add some default FormHelper configuration to make it work with Bootstrap field validations by default. Didn't find a good way to "include" it globally, in CakePHP2 so for now it's manually included in relevant forms. As a bonus, this also lets us clean up a lot of boilerplate from form/input related templates.

Changes:
- A lot clearer indication of validation errors on profile related forms
- Adds shared `useBootstrapForms` method which configures FormHelper with some bootstrap-friendly defaults
- Updates Profile related forms to use the shared defaults (to show how it's used, and make it easier to adopt other places later)
