### PR TITLE
Privacy page improvements

### DIFF
--- a/app/Controller/PrivacyController.php
+++ b/app/Controller/PrivacyController.php
@@ -4,7 +4,7 @@
  *
  */
 class PrivacyController extends AppController {
-    var $uses = array('UserPrivacy');
+    var $uses = array('UserPrivacy', 'Wikipage');
 
     var $layout = 'responsive-default';
 
@@ -42,5 +42,16 @@ class PrivacyController extends AppController {
         $this->set('privacyNames', $privacyNames);
         $this->set('title_for_layout', __("Privacy"));
         $this->set('desc_for_layout', '');
+
+        $privacyPage = $this->Wikipage->find('first', array(
+            'conditions' => [
+                'title' => 'Privacy',
+                'event_id' => $this->Wannabe->event->id
+            ],
+            'order' => 'Wikipage.created DESC',
+        ));
+        if (!empty($privacyPage)) {
+            $this->set('privacyPage', $this->Wikipage->format($privacyPage, $this));
+        }
     }
 }

--- a/app/Controller/PrivacyController.php
+++ b/app/Controller/PrivacyController.php
@@ -5,6 +5,9 @@
  */
 class PrivacyController extends AppController {
     var $uses = array('UserPrivacy');
+
+    var $layout = 'responsive-default';
+
     public function index() {
         if($this->request->is('post')) {
             $this->request->data['UserPrivacy']['user_id'] = $this->Wannabe->user['User']['id'];
@@ -34,10 +37,10 @@ class PrivacyController extends AppController {
             'address' => __("Address"),
             'birth' => __("Birth"),
             'email' => __("Email address"),
-            'allow_crew' => __("Allow fellow crew members to see hidden info regardless of other privacy settings")
+            'allow_crew' => __("Allow members of your own crew to see hidden info")
         );
         $this->set('privacyNames', $privacyNames);
-        $this->set('title_for_layout', __("Privacy settings"));
+        $this->set('title_for_layout', __("Privacy"));
         $this->set('desc_for_layout', '');
     }
 }

--- a/app/Locale/nob/LC_MESSAGES/default.po
+++ b/app/Locale/nob/LC_MESSAGES/default.po
@@ -2040,15 +2040,13 @@ msgstr "E-postadresse"
 
 #: Controller/PrivacyController.php:37
 msgid ""
-"Allow fellow crew members to see hidden info regardless of other privacy "
-"settings"
+"Allow members of your own crew to see hidden info"
 msgstr ""
-"La andre crewmedlemmer se skjult informasjon uavhengig av andre "
-"innstillinger for personvern"
+"La medlemmer av ditt eget crew se skjult informasjon"
 
 #: Controller/PrivacyController.php:40
-msgid "Privacy settings"
-msgstr "Personverninnstillinger"
+msgid "Privacy"
+msgstr "Personvern"
 
 #: Controller/ProfileController.php:29 View/Profile/edit.ctp:8
 #: View/Profile/email.ctp:8 View/Profile/password.ctp:8
@@ -7383,9 +7381,21 @@ msgstr "Lagre regel"
 msgid "Rules"
 msgstr "Regler"
 
-#: View/Privacy/index.ctp:4
-msgid "Hide…"
-msgstr "Skjul…"
+#: View/Privacy/index.ctp:3
+msgid "Settings"
+msgstr "Innstillinger"
+
+#: View/Privacy/index.ctp:6
+msgid "Hidden info"
+msgstr "Skjult info"
+
+#: View/Privacy/index.ctp:16
+msgid "Exceptions…"
+msgstr "Unntak…"
+
+#: View/Privacy/index.ctp:24
+msgid "Administrators, Chiefs and others with special access will always be allowed to access your contact information"
+msgstr "Administratorer, Chiefs og andre med spesialtilganger vil alltid ha anledning til å se din kontaktinformasjon"
 
 #: View/Profile/edit.ctp:4
 msgid "On this page you edit your profile."

--- a/app/View/Privacy/index.ctp
+++ b/app/View/Privacy/index.ctp
@@ -1,32 +1,29 @@
-<form method="POST">
-<fieldset>
-    <div class="clearfix">
-        <label id="optionscheckboxes" for="data[UserPrivacy][user_id]"><?=__('Hide…')?></label>
-        <div class="input">
-            <ul class="inputs-list">
-                <?php foreach($privacy['UserPrivacy'] as $name => $item) { 
-                    if($name == 'user_id' || $name == 'allow_crew') continue; ?>
-                    <li>
-                        <label>
-                            <?=$this->Form->checkbox('UserPrivacy.'.$name, array('div' => 'false', 'checked' => $item))?>
-                            <span><?=$privacyNames[$name]?></span>
-                        </label>
-                    </li>
-                <?php } ?>
-
-                <hr />
-
-                <li>
-                    <label>
-                        <?=$this->Form->checkbox('UserPrivacy.'.$name, array('div' => 'false', 'checked' => $privacy['UserPrivacy']['allow_crew']))?>
-                        <span><?=$privacyNames['allow_crew']?></span>
-                    </label>
-                </li>
-            </ul>
-        </div>
+<form method="POST" class="panel panel-primary">
+    <div class="panel-heading">
+        <?=__('Settings')?>
     </div>
-</fieldset>
-<div class="actions">
-    <?=$this->Form->submit(__("Save settings"), array('class' => 'btn success','name'=>'save'))?>
-</div>
+    <div class="panel-body">
+        <label id="optionscheckboxes" for="data[UserPrivacy][user_id]"><strong><?=__('Hidden info')?></strong></label>
+        <div class="form-group">
+            <?php foreach($privacy['UserPrivacy'] as $name => $item) {
+                if($name == 'user_id' || $name == 'allow_crew') continue; ?>
+                <label class="checkbox-inline">
+                    <?=$this->Form->checkbox('UserPrivacy.'.$name, array('class' => 'form-check-input', 'div' => false, 'checked' => $item))?>
+                    <?=$privacyNames[$name]?>
+                </label>
+            <?php } ?>
+        </div>
+        <label for="data[UserPrivacy][user_id]"><strong><?=__('Exceptions…')?></strong></label>
+        <div class="form-group">
+            <label class="checkbox-inline">
+                <?=$this->Form->checkbox('UserPrivacy.'.$name, array('div' => 'false', 'checked' => $privacy['UserPrivacy']['allow_crew']))?>
+                <?=$privacyNames['allow_crew']?>
+            </label>
+        </div>
+        <hr />
+        <p><?=__("Administrators, Chiefs and others with special access will always be allowed to access your contact information")?></p>
+    </div>
+    <div class="panel-footer">
+        <?=$this->Form->submit(__("Save settings"), array('class' => 'btn btn-success','name'=>'save'))?>
+    </div>
 </form>

--- a/app/View/Privacy/index.ctp
+++ b/app/View/Privacy/index.ctp
@@ -27,3 +27,17 @@
         <?=$this->Form->submit(__("Save settings"), array('class' => 'btn btn-success','name'=>'save'))?>
     </div>
 </form>
+<?
+    if (!empty($privacyPage)) {
+?>
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <?=__('Info')?>
+        </div>
+        <div class="panel-body">
+            <?=$privacyPage['Wikipage']['content']?>
+        </div>
+    </div>
+<?
+    }
+?>


### PR DESCRIPTION
The related issue lists a couple of pieces of information that should be available on the privacy settings page. Most of these seem very likely to change over time and different between events. So instead of hard coding these texts it instead includes the `Wiki/Privacy` page if defined.

Additionally I did some tweaks to existing phrasing and translations, restructuring layout to make it clearer, and added a disclaimer about "users with special privileges".

Fixes: https://github.com/gathering/wannabe/issues/25

**Preview (dummy data from wiki page in bottom "Informasjon" panel):**

<img width="517" alt="Screenshot 2019-10-09 at 00 00 57" src="https://user-images.githubusercontent.com/4913255/66436674-ffef2e80-ea27-11e9-995c-23b0f9f3f7f3.png">