### PR TITLE
Use console logging when running via docker-compose

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -39,16 +39,27 @@ Configure::write('Dispatcher.filters', array(
 ));
 
 // Add logging configuration.
-CakeLog::config('debug', array(
-    'engine' => 'FileLog',
-    'types' => array('notice', 'info', 'debug'),
-    'file' => 'debug',
-));
-CakeLog::config('error', array(
-    'engine' => 'FileLog',
-    'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
-    'file' => 'error',
-));
+if (env('LOG_ENGINE') === 'console') {
+    CakeLog::config('debug', array(
+        'engine' => 'ConsoleLog',
+        'types' => array('notice', 'info', 'debug'),
+    ));
+    CakeLog::config('error', array(
+        'engine' => 'ConsoleLog',
+        'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
+    ));
+} else {
+    CakeLog::config('debug', array(
+        'engine' => 'FileLog',
+        'types' => array('notice', 'info', 'debug'),
+        'file' => 'debug',
+    ));
+    CakeLog::config('error', array(
+        'engine' => 'FileLog',
+        'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
+        'file' => 'error',
+    ));
+}
 
 /**
  * The settings below can be used to set additional paths to models, views and controllers.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,7 @@ services:
       - MYSQL_PASSWORD=wannabe
       - AUTH_COOKIE_KEY=if-you-see-me-in-prod-run-away
       - APP_ENV=development
+      - LOG_ENGINE=console
     restart: "no"
 
   mysql:


### PR DESCRIPTION
Simple tweak to allow selecting between file and console logging engines, and using the later when run via docker-compose. This fixes the issue where only apache logs where output from app to docker logs.