### PR TITLE
Automatic Slack invite at Enroll Accept

### DIFF
--- a/app/Config/core.example.php
+++ b/app/Config/core.example.php
@@ -343,3 +343,10 @@ Cache::config('_cake_model_', array(
 	'duration' => $duration
 
 ));
+
+/**
+ * Slack automatic invite 
+ * LEGACY TOKEN
+ */
+
+Configure::write('Slack.token', '');

--- a/app/Controller/EnrollController.php
+++ b/app/Controller/EnrollController.php
@@ -423,11 +423,11 @@ class EnrollController extends AppController {
 		 * This is a quick and dirty hack to automatically send a Slack invite when accepting a crew member. 
 		 */
 
-		$slack_token = Configure::read('Slack.token');
 
-		if(isset($slack_token) && $slack_token != ""){
+		if(Configure::check('Slack.token')) {
 			// Slack token is set in configuration, lets go!
 			// TODO: Implement check against event settings
+			$slack_token = Configure::read('Slack.token');
 
 			$HttpSocket = new HttpSocket();
 			try{
@@ -445,10 +445,9 @@ class EnrollController extends AppController {
 			} catch (Exception $e) {
 				// Failed to invite user..
 				// TODO: Better error handling
-				return false;
 			} 
 
-		} 
+		} else { return true; } 
 	} 
 
 	public function wait() {

--- a/app/Locale/eng/LC_MESSAGES/default.po
+++ b/app/Locale/eng/LC_MESSAGES/default.po
@@ -8714,3 +8714,17 @@ msgstr "Crew you administrate"
 #: View/Crew/edit.ctp:94
 msgid "crewuser-customtitle"
 msgstr "If applicable, define a custom role or responsibility for this crew member."
+
+#: View/EnrollAdmin/index.ctp:32
+msgid "Enable automatic Slack invitations"
+msgstr "Enable automatic Slack invitations"
+
+#: app/Controller/EnrollController:
+msgid "Slack invite failed to send to user. User might already be in workspace, or user needs to be manually activated. Please contact support."
+msgstr "Slack invite failed to send to user. User might already be in workspace, or user needs to be manually activated. Please contact support."
+
+msgid "Slack invite to sent to user."
+msgstr "Slack invite to sent to user."
+
+msgid "Slack invite failed to send to user."
+msgstr "Slack invite failed to send to user."

--- a/app/Locale/nob/LC_MESSAGES/default.po
+++ b/app/Locale/nob/LC_MESSAGES/default.po
@@ -8740,3 +8740,17 @@ msgstr "Du er nå i ferd med å oppgi sensitive personopplysninger. I tråd med 
 #: View/Crew/edit.ctp:94
 msgid "crewuser-customtitle"
 msgstr "Definer eventuelt en tilpasset tittel eller rolle for crewmedlemmet."
+
+#: View/EnrollAdmin/index.ctp:32
+msgid "Enable automatic Slack invitations"
+msgstr "Aktiver automatiske Slack invitasjoner"
+
+#: app/Controller/EnrollController:
+msgid "Slack invite failed to send to user. User might already be in workspace, or user needs to be manually activated. Please contact support."
+msgstr "Slack invitasjon feilet, brukeren er kanskje allerede i Slack, eller brukeren må bli aktivert manuelt. Vennligst ta kontakt med support."
+
+msgid "Slack invite to sent to user."
+msgstr "Slack invitasjon sendt til brukeren!"
+
+msgid "Slack invite failed to send to user."
+msgstr "Slack invitasjon feilet."

--- a/app/View/EnrollAdmin/index.ctp
+++ b/app/View/EnrollAdmin/index.ctp
@@ -26,6 +26,12 @@
 									<span><?=__("Enable greetings")?></span>
 								</label>
 							</li>
+							<li>
+								<label>
+									<?=$this->Form->checkbox('EnrollSetting.slackactive', array('div' => false, 'label' => false, 'checked' => $setting['EnrollSetting']['slackactive']?'checked':''))?>
+									<span><?=__("Enable automatic Slack invitations")?></span>
+								</label>
+							</li>
 						</ul>
 					</div>
 				</div>

--- a/migrate/.migrations/20191120081814_added_slack_integration.migration
+++ b/migrate/.migrations/20191120081814_added_slack_integration.migration
@@ -1,0 +1,8 @@
+#-*- coding:utf-8 -*-
+SQL_UP = u"""
+alter table wb4_enroll_settings add slackactive tinyint(1) DEFAULT '0';
+"""
+
+SQL_DOWN = u"""
+alter table wb4_enroll_settings drop slackactive;
+"""


### PR DESCRIPTION
This is a simple and hacky implementation of an automatic Slack invite that happens at Enroll Accept. The implementation is based on the Slack Legacy API. This sadly means that it will not work forever. But, lets hope it works for us this year, and maybe next year.

Would be great to have this in prod by 18:00 today. 