### PR TITLE
Adding support for other genders than male and female

### DIFF
--- a/app/Controller/ProfileController.php
+++ b/app/Controller/ProfileController.php
@@ -426,7 +426,7 @@ class ProfileController extends AppController {
             }
             $this->set('user', $user);
         }
-        $this->set('sexes', array('male'=>__('male'),'female'=>__('female'),'other'=>('other'),'na'=>('prefer not to say')));
+        $this->set('sexes', array('male'=>__('male'),'female'=>__('female'),'other'=>__('other'),'na'=>__('prefer not to say')));
         $this->set('countrycodes', $this->Country->find('list'));
         $this->set('phonetypes', $this->Phonetype->find('list'));
         $this->set('improtocols', $this->Improtocol->find('list'));

--- a/app/Controller/ProfileController.php
+++ b/app/Controller/ProfileController.php
@@ -426,7 +426,7 @@ class ProfileController extends AppController {
             }
             $this->set('user', $user);
         }
-        $this->set('sexes', array('male'=>__('male'),'female'=>__('female')));
+        $this->set('sexes', array('male'=>__('male'),'female'=>__('female'),'other'=>('other'),'na'=>('prefer not to say')));
         $this->set('countrycodes', $this->Country->find('list'));
         $this->set('phonetypes', $this->Phonetype->find('list'));
         $this->set('improtocols', $this->Improtocol->find('list'));

--- a/app/Locale/default.po
+++ b/app/Locale/default.po
@@ -2046,6 +2046,10 @@ msgstr ""
 msgid "female"
 msgstr ""
 
+#: Controller/ProfileController.php:353
+msgid "other"
+msgstr ""
+
 #: Controller/ProfileController.php:358
 #: View/Layouts/default.ctp:85
 #: View/Layouts/fullscreen.ctp:71

--- a/app/Locale/default.po
+++ b/app/Locale/default.po
@@ -2050,6 +2050,10 @@ msgstr ""
 msgid "other"
 msgstr ""
 
+#: Controller/ProfileController.php:353
+msgid "prefer not to say"
+msgstr ""
+
 #: Controller/ProfileController.php:358
 #: View/Layouts/default.ctp:85
 #: View/Layouts/fullscreen.ctp:71

--- a/app/Locale/eng/LC_MESSAGES/default.po
+++ b/app/Locale/eng/LC_MESSAGES/default.po
@@ -2142,6 +2142,11 @@ msgstr "male"
 msgid "female"
 msgstr "female"
 
+#: Controller/ProfileController.php:410
+msgid "other"
+msgstr "other"
+
+
 #: Controller/ProfileController.php:415 View/Layouts/default.ctp:88
 #: View/Layouts/fullscreen.ctp:71 View/Profile/register.ctp:3
 msgid "Complete registration"

--- a/app/Locale/eng/LC_MESSAGES/default.po
+++ b/app/Locale/eng/LC_MESSAGES/default.po
@@ -2146,6 +2146,9 @@ msgstr "female"
 msgid "other"
 msgstr "other"
 
+#: Controller/ProfileController.php:410
+msgid "prefer not to say"
+msgstr "prefer not to say"
 
 #: Controller/ProfileController.php:415 View/Layouts/default.ctp:88
 #: View/Layouts/fullscreen.ctp:71 View/Profile/register.ctp:3

--- a/app/Locale/nob/LC_MESSAGES/default.po
+++ b/app/Locale/nob/LC_MESSAGES/default.po
@@ -2141,6 +2141,14 @@ msgstr "mann"
 msgid "female"
 msgstr "kvinne"
 
+#: Controller/ProfileController.php:410
+msgid "other"
+msgstr "annet"
+
+#: Controller/ProfileController.php:410
+msgid "prefer not to say"
+msgstr "foretrekker å ikke svare"
+
 #: Controller/ProfileController.php:415 View/Layouts/default.ctp:88
 #: View/Layouts/fullscreen.ctp:71 View/Profile/register.ctp:3
 msgid "Complete registration"

--- a/sql/dev.sql
+++ b/sql/dev.sql
@@ -3052,7 +3052,7 @@ CREATE TABLE `wb4_users` (
   `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `updated` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `deleted` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `sexe` enum('undefined','male','female') DEFAULT 'undefined',
+  `sexe` enum('undefined','male','female','other','na') DEFAULT 'undefined',
   `verified` datetime NOT NULL,
   `verificationcode` varchar(128) DEFAULT NULL,
   `nickname` varchar(128) NOT NULL,


### PR DESCRIPTION
Fixes #57. New choices are 'other' and 'prefer not to say', in compliance with guidelines on the subject from HRC.org.

**Column wb4_users must include 'other' and 'na' in enum for fix to work.**

Language files are updated with new options, but this is not reflected in the UI with this fix. Could someone help out and see why translations are not being applied?