### PR TITLE
Enable editing of FrontNews items regardless of user language

### DIFF
--- a/app/Controller/FrontNewsManagerController.php
+++ b/app/Controller/FrontNewsManagerController.php
@@ -28,6 +28,7 @@ class FrontNewsManagerController extends AppController {
 		$this->set('title_for_layout', __("Add news"));
 	}
 	public function edit($id = null) {
+		$this->set('desc_for_layout', $this->FrontNews->locale === 'nob' ? __("Norwegian translation") : __("English translation"));
 		$this->FrontNews->id = $id;
 		if($this->request->is('get')) {
 			$this->request->data = $this->FrontNews->read();
@@ -59,6 +60,5 @@ class FrontNewsManagerController extends AppController {
 		// Fall back to user/system defaults
 		$locale = empty($reqLocale) ? $this->Wannabe->lang : $reqLocale;
 		$this->FrontNews->locale = $locale;
-		$this->set('desc_for_layout', $locale === 'nob' ? __("Norwegian translation") : __("English translation"));
 	}
 }

--- a/app/Controller/FrontNewsManagerController.php
+++ b/app/Controller/FrontNewsManagerController.php
@@ -6,6 +6,7 @@
 class FrontNewsManagerController extends AppController {
 
 	public $uses = array('FrontNews');
+
 	public function index() {
 		$this->set('frontNews', $this->FrontNews->find('all'));
 		$this->set('title_for_layout', __("Front news"));
@@ -18,7 +19,6 @@ class FrontNewsManagerController extends AppController {
 	}
 	public function add() {
 		if($this->request->is('post')) {
-			$this->FrontNews->locale = $this->Wannabe->lang;
 			if($this->FrontNews->save($this->request->data)) {
 				Cache::delete('news'.$this->Wannabe->lang);
 				$this->Flash->success(__("The news has been saved."));
@@ -31,8 +31,8 @@ class FrontNewsManagerController extends AppController {
 		$this->FrontNews->id = $id;
 		if($this->request->is('get')) {
 			$this->request->data = $this->FrontNews->read();
-		} else {
-			$this->Post->locale = $this->Wannabe->lang;
+		} elseif ($this->request->is('post')) {
+			$this->FrontNews->locale = $this->request->data['locale'];
 			if($this->FrontNews->save($this->request->data)) {
 				Cache::delete('news'.$this->Wannabe->lang);
 				$this->Flash->success(__("The news has been saved."));
@@ -42,4 +42,23 @@ class FrontNewsManagerController extends AppController {
 		$this->set('title_for_layout', __("Edit %s", $this->request->data['FrontNews']['name']));
 	}
 
+	// Automatically set locale for FrontNews and relevant page variables
+	public function beforeFilter() {
+		parent::beforeFilter();
+		$reqLocale = '';
+
+		// Get from query argument on get requests
+		if ($this->request->is('get') && isset($this->request->query['locale'])) {
+			$reqLocale = $this->request->query['locale'];
+		}
+		// Get from form data on post requests
+		if ($this->request->is('post') && isset($this->request->data['locale'])) {
+			$reqLocale = $this->request->data['locale'];
+		}
+
+		// Fall back to user/system defaults
+		$locale = empty($reqLocale) ? $this->Wannabe->lang : $reqLocale;
+		$this->FrontNews->locale = $locale;
+		$this->set('desc_for_layout', $locale === 'nob' ? __("Norwegian translation") : __("English translation"));
+	}
 }

--- a/app/Model/FrontNews.php
+++ b/app/Model/FrontNews.php
@@ -12,7 +12,14 @@ class FrontNews extends AppModel {
 	public $displayField = 'name';
 	public $actsAs = array(
 		'Translate' => array(
-			'title', 'content'
+			'title', 'content',
+			/**
+			 * During item creation on admin pages usually only norwegian or
+			 * english version of each item is created. Activating `left` makes
+			 * sure all of these appear in admin panels, to allow adding the
+			 * translated versions without changing user language.
+			 */
+			'joinType' => 'left',
 		)
 	);
 }

--- a/app/View/FrontNewsManager/add.ctp
+++ b/app/View/FrontNewsManager/add.ctp
@@ -2,6 +2,12 @@
 	<fieldset>
 		<legend><?=__("Create news")?></legend>
 		<div class="clearfix">
+			<label for="data[locale]"><?=__("Locale")?></label>
+			<div class="input">
+				<?=$this->Form->input('locale', array('label' => false, 'div' => false, 'options' => array('nob' => __('Norwegian'), 'eng' => __('English'))))?>
+			</div>
+		</div>
+		<div class="clearfix">
 			<label for="data[name]"><?=__("Name")?></label>
 			<div class="input">
 				<?=$this->Form->input('name', array('label' => false, 'div' => false))?>
@@ -11,12 +17,14 @@
 			<label for="data[title]"><?=__("Title")?></label>
 			<div class="input">
 				<?=$this->Form->input('title', array('label' => false, 'div' => false))?>
+				<span class="help-inline"><?=__("Translated")?></span>
 			</div>
 		</div>
 		<div class="clearfix">
 			<label for="data[title]"><?=__("Content")?></label>
 			<div class="input">
 				<?=$this->Form->textarea('content', array('rows' => 3, 'class' => 'xxlarge', 'label' => false, 'div' => false, 'id' => 'frontnewscontent'))?>
+				<span class="help-inline"><?=__("Translated")?></span>
 			</div>
 		</div>
 		<div class="clearfix">

--- a/app/View/FrontNewsManager/edit.ctp
+++ b/app/View/FrontNewsManager/edit.ctp
@@ -2,6 +2,7 @@
 	<fieldset>
 		<legend><?=__("Edit %s", $this->data['FrontNews']['name'])?></legend>
 		<?=$this->Form->hidden('id', array('value' => $this->data['FrontNews']['id']))?>
+		<?=$this->Form->hidden('locale', array('value' => $this->data['FrontNews']['locale']))?>
 		<div class="clearfix">
 			<label for="data[name]"><?=__("Name")?></label>
 			<div class="input">
@@ -12,12 +13,14 @@
 			<label for="data[title]"><?=__("Title")?></label>
 			<div class="input">
 				<?=$this->Form->input('title', array('value' => $this->data['FrontNews']['title'], 'label' => false, 'div' => false))?>
+				<span class="help-inline"><?=__("Translated")?></span>
 			</div>
 		</div>
 		<div class="clearfix">
 			<label for="data[title]"><?=__("Content")?></label>
 			<div class="input">
 				<?=$this->Form->textarea('content', array('rows' => 3, 'class' => 'xxlarge', 'value' => $this->data['FrontNews']['content'], 'label' => false, 'div' => false, 'id' => 'frontnewscontent'))?>
+				<span class="help-inline"><?=__("Translated")?></span>
 			</div>
 		</div>
 		<div class="clearfix">
@@ -42,6 +45,7 @@
 	</fieldset>
 	<div class="actions">
 		<?=$this->Form->submit(__("Save news"), array('label' => false, 'div' => false, 'class' => 'btn success'))?>
-		<a href="<?=$this->Wb->eventUrl("/FrontNewsManager")?>" class="btn"><?=__("Back")?></a>
+		<a href="<?=$this->Wb->eventUrl("/FrontNewsManager")?>" class="btn"><?=__("Back")?></a>&nbsp;
+		<a href="<?=$this->Wb->eventUrl("/FrontNewsManager/edit/".$this->data['FrontNews']['id']."?locale=".($this->data['FrontNews']['locale'] === 'nob' ? 'eng' : 'nob'))?>"><?= $this->data['FrontNews']['locale'] === 'nob' ? __("To English version") : __("To Norwegian version")?></a>
 	</div>
 </form>

--- a/app/View/FrontNewsManager/index.ctp
+++ b/app/View/FrontNewsManager/index.ctp
@@ -2,20 +2,21 @@
 	<tr>
 		<th>#</th>
 		<th><?=__("Name")?></th>
-		<th><?=__("Title")?></th>
 		<th><?=__("Left")?></th>
 		<th><?=__("Active")?></th>
 	</tr>
 
 	<?php foreach($frontNews as $news): ?>
 	<tr>
-		<td><?=$this->Wb->eventLink($news['FrontNews']['id'], "/FrontNewsManager/edit/{$news['FrontNews']['id']}")?></td>
+		<td>
+			<?=$this->Wb->eventLink('en', "/FrontNewsManager/edit/{$news['FrontNews']['id']}?locale=eng")?> /
+			<?=$this->Wb->eventLink('no', "/FrontNewsManager/edit/{$news['FrontNews']['id']}?locale=nob")?>
+		</td>
 		<td><?=$news['FrontNews']['name']?></td>
-		<td><?=$news['FrontNews']['title']?></td>
 		<td><?=$news['FrontNews']['left_box']?></td>
 		<td><?=$news['FrontNews']['active']?></td>
 	</tr>
 	<?php endforeach; ?>
 
 </table>
-	<a href="<?=$this->Wb->eventUrl('/FrontNewsManager/add')?>" class="btn success"><?=__("Create new")?></a>
+<a href="<?=$this->Wb->eventUrl('/FrontNewsManager/add')?>" class="btn success"><?=__("Create new")?></a>


### PR DESCRIPTION
Turns out the existing behaviour was a bit stranger than expected. Currently they don't really translate FrontNews items, but instead create completely separate entries for English and Norwegian. Since user only saw items available in his/her own locale, there wasn't really a way to see, and much less add translations to existing items from other languages.

To keep things simple (while working around Translation class issues) I kept editing of different translations on separate page views, but with easy navigation in between... independent of user language. We also only take the existing `nob` and `eng` languages into account.

In order to allow editing of existing items we had to allow Translation class to return items missing translations for active locale. When this is merged any active FrontNews items needs to be updated (via admin pages) with translations for both languages, and the duplicates set to inactive.

Fixes: https://github.com/gathering/wannabe/issues/14